### PR TITLE
Added in the ability for a "pre-processor" of the batches in haystack.

### DIFF
--- a/haystack/indexes.py
+++ b/haystack/indexes.py
@@ -351,7 +351,7 @@ class SearchIndex(with_metaclass(DeclarativeMetaclass, threading.local)):
 
     def pre_process_data(self, queryset):
         """
-        Will allow an "index" to do some preprocessing of the data in it's slice
+        Will allow an "index" to do some preprocessing of the data in its slice
         before the actual data is indexed
         """
 

--- a/haystack/indexes.py
+++ b/haystack/indexes.py
@@ -349,6 +349,12 @@ class SearchIndex(with_metaclass(DeclarativeMetaclass, threading.local)):
         """
         return self.get_model()._default_manager.all()
 
+    def pre_process_data(self, queryset):
+        """
+        Will allow an "index" to do some preprocessing of the data in it's slice
+        before the actual data is indexed
+        """
+
 
 class BasicSearchIndex(SearchIndex):
     text = CharField(document=True, use_template=True)

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -79,6 +79,8 @@ def do_update(backend, index, qs, start, end, total, verbosity=1):
     small_cache_qs = qs.all()
     current_qs = small_cache_qs[start:end]
 
+    index.pre_process_data(current_qs)
+
     if verbosity >= 2:
         if hasattr(os, 'getppid') and os.getpid() == os.getppid():
             print("  indexed %s - %d of %d." % (start + 1, end, total))


### PR DESCRIPTION
see https://github.com/RueLaLa/rue-storefront/pull/2901 as well. 

This allows someone to do certain things outside of the base object layer.

An example:  You have to call a 3rd party for some data and it is better
to do it in bulk once and then do a lookup in memory while looping through
the individual document creation.  This could avoid tons of round trip
requests to that 3rd party.
