### PR TITLE
[CATS-383] Improved threading, logging, and error messaging for Haystack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ env3
 
 test_haystack/solr_tests/server/solr-4.6.0.tgz
 test_haystack/solr_tests/server/solr4/
+
+.idea

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -12,7 +12,7 @@ from django.utils import six
 import haystack
 from haystack.backends import BaseEngine, BaseSearchBackend, BaseSearchQuery, log_query
 from haystack.constants import DEFAULT_OPERATOR, DJANGO_CT, DJANGO_ID, ID
-from haystack.exceptions import MissingDependency, MoreLikeThisError
+from haystack.exceptions import ConnectionError, MissingDependency, MoreLikeThisError
 from haystack.inputs import Clean, Exact, PythonData, Raw
 from haystack.models import SearchResult
 from haystack.utils import log as logging
@@ -184,7 +184,10 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                     }
                 })
 
-        bulk_index(self.conn, prepped_docs, index=self.index_name, doc_type='modelresult')
+        try:
+            bulk_index(self.conn, prepped_docs, index=self.index_name, doc_type='modelresult')
+        except elasticsearch.exceptions.ConnectionError as ce:
+            raise ConnectionError('Could not connect to the ElasticSearch server for index \'{}\' ({})'.format(self.index_name, ce.info))
 
         if commit:
             self.conn.indices.refresh(index=self.index_name)
@@ -490,7 +493,8 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
         try:
             raw_results = self.conn.search(body=search_kwargs,
                                            index=self.index_name,
-                                           doc_type='modelresult')
+                                           doc_type='modelresult',
+                                           _source=True)
         except elasticsearch.TransportError as e:
             if not self.silently_fail:
                 raise

--- a/haystack/exceptions.py
+++ b/haystack/exceptions.py
@@ -36,3 +36,7 @@ class SpatialError(HaystackError):
 class StatsError(HaystackError):
     "Raised when incorrect arguments have been provided for stats"
     pass
+
+class ConnectionError(HaystackError):
+    "Raised when there's a problem with the connection to the backend"
+    pass

--- a/haystack/management/commands/clear_index.py
+++ b/haystack/management/commands/clear_index.py
@@ -43,7 +43,7 @@ class Command(BaseCommand):
                 sys.exit()
 
         if self.verbosity >= 1:
-            print("Removing all documents from your index because you said so.")
+            print("Removing all documents from your index because you said so...")
 
         for backend_name in using:
             backend = connections[backend_name].get_backend()

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -11,6 +11,7 @@ from django.core.management.base import LabelCommand
 from django.db import reset_queries
 
 from haystack import connections as haystack_connections
+from haystack.exceptions import ConnectionError
 from haystack.query import SearchQuerySet
 from haystack.utils.app_loading import get_models, load_apps
 
@@ -30,11 +31,46 @@ except ImportError:
     from datetime import datetime
     now = datetime.now
 
+from timeit import default_timer
 
 DEFAULT_BATCH_SIZE = None
 DEFAULT_AGE = None
 APP = 'app'
 MODEL = 'model'
+WORKER_TIMEOUT = 60 # seconds
+
+
+def format_timedelta(td_object):
+    """
+    Turns a timedelta object into a string formatted such as:
+        "1 day, 3 hours, 38 minutes, 20 seconds"
+    (Adapted from http://stackoverflow.com/a/13756038)
+    """
+    seconds = int(td_object.total_seconds())
+
+    if not seconds:
+        return 'less than a second'
+
+    periods = [
+            ('year',        60*60*24*365),
+            ('month',       60*60*24*30),
+            ('day',         60*60*24),
+            ('hour',        60*60),
+            ('minute',      60),
+            ('second',      1)
+    ]
+
+    strings = []
+
+    for period_name, period_seconds in periods:
+        if seconds >= period_seconds:
+            period_value, seconds = divmod(seconds, period_seconds)
+            if period_value == 1:
+                strings.append("%s %s" % (period_value, period_name))
+            else:
+                strings.append("%s %ss" % (period_value, period_name))
+
+    return ', '.join(strings)
 
 
 def worker(bits):
@@ -56,59 +92,35 @@ def worker(bits):
                 pass
 
     if bits[0] == 'do_update':
-        func, model, start, end, total, using, start_date, end_date, verbosity = bits
-    elif bits[0] == 'do_remove':
-        func, model, pks_seen, start, upper_bound, using, verbosity = bits
+        func, model, start, end, total, using, start_date, end_date, verbosity = bits[:9]
     else:
-        return
+        raise NotImplementedError('Unknown function %s' % bits[0])
 
-    unified_index = haystack_connections[using].get_unified_index()
-    index = unified_index.get_index(model)
     backend = haystack_connections[using].get_backend()
+    index = haystack_connections[using].get_unified_index().get_index(model)
+    query_set = index.build_queryset(start_date=start_date, end_date=end_date)
 
-    if func == 'do_update':
-        qs = index.build_queryset(start_date=start_date, end_date=end_date)
-        do_update(backend, index, qs, start, end, total, verbosity=verbosity)
-    elif bits[0] == 'do_remove':
-        do_remove(backend, index, model, pks_seen, start, upper_bound, verbosity=verbosity)
+    do_update(backend, index, query_set, start, end, total, verbosity=verbosity)
 
 
-def do_update(backend, index, qs, start, end, total, verbosity=1):
+def do_update(backend, index, query_set, start, end, total, verbosity=1):
     # Get a clone of the QuerySet so that the cache doesn't bloat up
     # in memory. Useful when reindexing large amounts of data.
-    small_cache_qs = qs.all()
-    current_qs = small_cache_qs[start:end]
+    current_qs = query_set.all()[start:end]
 
     index.pre_process_data(current_qs)
 
     if verbosity >= 2:
+        base_text = '  indexing {1:>{0}} - {2:>{0}} (of {3:>{0}})'.format(len(str(total)), start + 1, end, total)
         if hasattr(os, 'getppid') and os.getpid() == os.getppid():
-            print("  indexed %s - %d of %d." % (start + 1, end, total))
+            print(base_text)
         else:
-            print("  indexed %s - %d of %d (by %s)." % (start + 1, end, total, os.getpid()))
+            print('{} [by {}]'.format(base_text, os.getpid()))
 
-    # FIXME: Get the right backend.
     backend.update(index, current_qs)
 
     # Clear out the DB connections queries because it bloats up RAM.
     reset_queries()
-
-
-def do_remove(backend, index, model, pks_seen, start, upper_bound, verbosity=1):
-    # Fetch a list of results.
-    # Can't do pk range, because id's are strings (thanks comments
-    # & UUIDs!).
-    stuff_in_the_index = SearchQuerySet(using=backend.connection_alias).models(model)[start:upper_bound]
-
-    # Iterate over those results.
-    for result in stuff_in_the_index:
-        # Be careful not to hit the DB.
-        if not smart_bytes(result.pk) in pks_seen:
-            # The id is NOT in the small_cache_qs, issue a delete.
-            if verbosity >= 2:
-                print("  removing %s." % result.pk)
-
-            backend.remove(".".join([result.app_label, result.model_name, str(result.pk)]))
 
 
 class Command(LabelCommand):
@@ -142,6 +154,10 @@ class Command(LabelCommand):
             default=0, type='int',
             help='Allows for the use multiple workers to parallelize indexing. Requires multiprocessing.'
         ),
+        make_option('-t', '--timeout', action='store', dest='timeout',
+            default=WORKER_TIMEOUT, type='float',
+            help='Number of seconds after which a worker process will be considered timed out'
+        ),
     )
     option_list = LabelCommand.option_list + base_options
 
@@ -152,10 +168,11 @@ class Command(LabelCommand):
         self.end_date = None
         self.remove = options.get('remove', False)
         self.workers = int(options.get('workers', 0))
-
         self.backends = options.get('using')
         if not self.backends:
             self.backends = haystack_connections.connections_info.keys()
+        self.timeout = options.get('timeout')
+        self.logger = logging.getLogger('haystack')
 
         age = options.get('age', DEFAULT_AGE)
         start_date = options.get('start_date')
@@ -185,13 +202,43 @@ class Command(LabelCommand):
 
         return super(Command, self).handle(*items, **options)
 
+    def log_info(self, message):
+        self.logger.info('[Haystack] {}'.format(message))
+
+    def log_error(self, message):
+        self.logger.error('[Haystack] ERROR: {}'.format(message))
+
+    def log_debug(self, message):
+        self.logger.debug('[Haystack] (DEBUG) {}'.format(message))
+
     def handle_label(self, label, **options):
         for using in self.backends:
             try:
                 self.update_backend(label, using)
+            except ConnectionError as ce:
+                self.log_error('Encountered a connection error while attempting to update "{}" (using {}) "{}".'.format(label, using, ce.message))
+                pass
             except:
-                logging.exception("Error updating %s using %s ", label, using)
+                self.log_error('Encountered unknown issue while attempting to update "{}" (using {})'.format(label, using))
                 raise
+
+    def log_start(self, model_set_name):
+        if self.verbosity >= 1:
+            self.time_start_model = default_timer()
+
+            self.log_info('Updating backend for: {}'.format(model_set_name))
+
+    def log_end(self, model_set_name):
+        if self.verbosity >= 1:
+            self.time_end_model = default_timer()
+
+            elapsed = timedelta(seconds=(self.time_end_model - self.time_start_model))
+
+            self.log_info('Finished updating backend for {}. It took {} ({:.2f}s) total.'.format(
+                model_set_name,
+                format_timedelta(elapsed),
+                elapsed.total_seconds()
+            ))
 
     def update_backend(self, label, using):
         from haystack.exceptions import NotHandled
@@ -199,77 +246,100 @@ class Command(LabelCommand):
         backend = haystack_connections[using].get_backend()
         unified_index = haystack_connections[using].get_unified_index()
 
-        if self.workers > 0:
-            import multiprocessing
-
         for model in get_models(label):
+            model_set_name = model._meta.verbose_name_plural
+
             try:
                 index = unified_index.get_index(model)
             except NotHandled:
                 if self.verbosity >= 2:
-                    print("Skipping '%s' - no index." % model)
+                    self.log_debug('Skipping "{}" - no index.'.format(model))
                 continue
 
-            if self.workers > 0:
+            self.log_start(model_set_name)
+
+            query_set = index.build_queryset(using=using, start_date=self.start_date,
+                                      end_date=self.end_date)
+
+            total = query_set.count()
+
+            if self.verbosity >= 1:
+                self.log_info('Indexing {} {}...'.format(total, force_text(model_set_name)))
+
+            batch_size = self.batchsize or backend.batch_size
+
+            batches = ((start, min(start + batch_size, total)) for start in range(0, total, batch_size))
+
+            if self.workers:
+                from pebble import process as p_town, TimeoutError
+
+                action_queue = [
+                    ('do_update', model, start, end, total, using, self.start_date, self.end_date, self.verbosity)
+                    for (start, end) in batches
+                ]
+
+                with p_town.Pool(workers=self.workers) as pool:
+                    jobs = [pool.schedule(worker, args=[action], timeout=self.timeout) for action in action_queue]
+
+                for job in jobs:
+                    try:
+                        job.get()
+                    except TimeoutError:
+                        self.log_error('A worker process timed out')
+
+                pool.stop()
+                pool.join()
+
                 # workers resetting connections leads to references to models / connections getting
                 # stale and having their connection disconnected from under them. Resetting before
                 # the loop continues and it accesses the ORM makes it better.
                 db.close_connection()
-
-            qs = index.build_queryset(using=using, start_date=self.start_date,
-                                      end_date=self.end_date)
-
-            total = qs.count()
-
-            if self.verbosity >= 1:
-                print(u"Indexing %d %s" % (total, force_text(model._meta.verbose_name_plural)))
-
-            batch_size = self.batchsize or backend.batch_size
-
-            if self.workers > 0:
-                ghetto_queue = []
-
-            for start in range(0, total, batch_size):
-                end = min(start + batch_size, total)
-
-                if self.workers == 0:
-                    do_update(backend, index, qs, start, end, total, self.verbosity)
-                else:
-                    ghetto_queue.append(('do_update', model, start, end, total, using, self.start_date, self.end_date, self.verbosity))
-
-            if self.workers > 0:
-                pool = multiprocessing.Pool(self.workers)
-                pool.map(worker, ghetto_queue)
-                pool.terminate()
+            else:
+                for (start, end) in batches:
+                    do_update(backend, index, query_set, start, end, total, self.verbosity)
 
             if self.remove:
-                # For some reason, if we don't close them all out, we find out that the connection
-                # has gone away. I assume this is because the remove is happening in the root
-                # process and that the connections are messed up.  This only happens when using 
-                # the -k or --workers flag.
-                db.close_connection()
-                if self.start_date or self.end_date or total <= 0:
-                    # They're using a reduced set, which may not incorporate
-                    # all pks. Rebuild the list with everything.
-                    qs = index.index_queryset().values_list('pk', flat=True)
-                    pks_seen = set(smart_bytes(pk) for pk in qs)
+                self.remove_items(backend, batch_size, index, model, True)
 
-                    total = len(pks_seen)
-                else:
-                    pks_seen = set(smart_bytes(pk) for pk in qs.values_list('pk', flat=True))
+            self.log_end(model_set_name)
 
-                if self.workers > 0:
-                    ghetto_queue = []
+    def remove_items(self, backend, batch_size, index, model, commit):
+        database_pks = list(smart_bytes(pk) for pk in index.index_queryset().values_list('pk', flat=True))
 
-                for start in range(0, total, batch_size):
-                    upper_bound = start + batch_size
+        search_query_set = SearchQuerySet(using=backend.connection_alias).models(model)
 
-                    if self.workers == 0:
-                        do_remove(backend, index, model, pks_seen, start, upper_bound)
-                    else:
-                        ghetto_queue.append(('do_remove', model, pks_seen, start, upper_bound, using, self.verbosity))
+        # Since records may still be in the search index but not the local database
+        # we'll use that to create batches for processing.
+        # See https://github.com/django-haystack/django-haystack/issues/1186
+        index_total_count = search_query_set.count()
 
-                if self.workers > 0:
-                    pool = multiprocessing.Pool(self.workers)
-                    pool.map(worker, ghetto_queue)
-                    pool.terminate()
+        # Retrieve PKs from the index. Note that this cannot be a numeric range query because although
+        # pks are normally numeric they can be non-numeric UUIDs or other custom values. To reduce
+        # load on the search engine, we only retrieve the pk field, which will be checked against the
+        # full list obtained from the database, and the id field, which will be used to delete the
+        # record should it be found to be stale.
+        all_index_pks = search_query_set.values_list('pk', 'id')
+
+        # We'll collect all of the record IDs which are no longer present in the database and delete
+        # them after walking the entire index. This uses more memory than the incremental approach but
+        # avoids needing the pagination logic below to account for both commit modes:
+        stale_records = set()
+
+        for start in range(0, index_total_count, batch_size):
+            upper_bound = start + batch_size
+
+            # If the database pk is no longer present, queue the index key for removal:
+            for pk, rec_id in all_index_pks[start:upper_bound]:
+                if smart_bytes(pk) not in database_pks:
+                    stale_records.add(rec_id)
+
+        if stale_records:
+            if self.verbosity >= 1:
+                self.log_info('  removing {} stale records...'.format(len(stale_records)))
+
+            for rec_id in stale_records:
+                # Since the PK was not in the database list, we'll delete the record from the search index:
+                if self.verbosity >= 2:
+                    self.log_info('    removing {}'.format(rec_id))
+
+                backend.remove(rec_id, commit=commit)


### PR DESCRIPTION
- Specific error messaging for connection errors
- Better incremental update logging and text formatting
- Can now specify a (float) number of seconds after which a given batch will be considered "timed out"

---

This addresses https://jira.ruelala.com/browse/CATS-383 and hopefully https://jira.ruelala.com/browse/CATS-526 as well.

---

The major thing this adds is a `-t` (`--timeout`) flag, the value of which is read and stored as a float, that you can pass `update_index` / `rebuild_index` that will cause it to bail out of a specific batch of updates and log the fact that it did so if any given batch takes longer than `timeout` seconds.

I also added a more detail and polish to how logging works to hopefully make it more clear and consistent.
