### PR TITLE
use bulk instead of bulk_index

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -20,7 +20,7 @@ from haystack.utils import get_identifier, get_model_ct
 
 try:
     import elasticsearch
-    from elasticsearch.helpers import bulk_index
+    from elasticsearch.helpers import bulk
     from elasticsearch.exceptions import NotFoundError
 except ImportError:
     raise MissingDependency("The 'elasticsearch' backend requires the installation of 'elasticsearch'. Please refer to the documentation.")
@@ -184,7 +184,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                     }
                 })
 
-        bulk_index(self.conn, prepped_docs, index=self.index_name, doc_type='modelresult')
+        bulk(self.conn, prepped_docs, index=self.index_name, doc_type='modelresult')
 
         # We are explicitly eliminating the call to self.conn.indices.refresh().
         # ElasticSearch will do an automatic refresh once per second. Manually invoking refresh


### PR DESCRIPTION
In elasticsearch 1.7, there was of a function called bulk, which the aliased to bulk_index... for some reason.  In 1.9 they stopped aliasing it.  So in 1.7 you can import bulk or you can import bulk_index.  In 1.9 you can import bulk, but not bulk_index.  With this change, this will work with both 1.7 and 1.9.

[Here is elasticsearch 1.7 defining a `bulk` function and then aliasing it to `bulk_index`](https://github.com/elastic/elasticsearch-py/blob/1.7.0/elasticsearch/helpers/__init__.py#L158-L195)

[Here is elasticsearch 1.9 defining a `bulk` function but then **NOT** aliasing it `bulk_index`](https://github.com/elastic/elasticsearch-py/blob/1.9.0/elasticsearch/helpers/__init__.py#L163-L197)

Notice how both implement the `bulk` function.  By importing `bulk` instead of `bulk_index` this should work with both elasticsearch 1.9 and 1.7.