### PR TITLE
Logging at ERROR level and should log at INFO

### DIFF
--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -11,7 +11,6 @@ __author__ = 'Daniel Lindsley'
 __version__ = (2, 1, 1, 'dev')
 
 
-
 # Help people clean up from 1.X.
 if hasattr(settings, 'HAYSTACK_SITECONF'):
     raise ImproperlyConfigured('The HAYSTACK_SITECONF setting is no longer used & can be removed.')

--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -11,12 +11,6 @@ __author__ = 'Daniel Lindsley'
 __version__ = (2, 1, 1, 'dev')
 
 
-# Setup default logging.
-log = logging.getLogger('haystack')
-stream = logging.StreamHandler()
-stream.setLevel(logging.INFO)
-log.addHandler(stream)
-
 
 # Help people clean up from 1.X.
 if hasattr(settings, 'HAYSTACK_SITECONF'):


### PR DESCRIPTION
All reindex logs are running at log level ERROR. Moving logs to INFO so they don't confuse us later when looking at logs more generally.