### PR TITLE
WEB-2469  Remove __unicode__ method call

### DIFF
--- a/haystack/inputs.py
+++ b/haystack/inputs.py
@@ -23,7 +23,7 @@ class BaseInput(object):
         self.kwargs = kwargs
 
     def __repr__(self):
-        return u"<%s '%s'>" % (self.__class__.__name__, self.__unicode__().encode('utf8'))
+        return u"<%s '%s'>" % (self.__class__.__name__, self.__str__())
 
     def __str__(self):
         return force_text(self.query_string)


### PR DESCRIPTION
JIRA: [WEB-2469](https://ruelala.atlassian.net/browse/WEB-2469)
The `__unicode__` method no longer exists in python3, so use the existing `__str__` method instead since it is already working for both python 2 and 3