### PR TITLE
Bug/web 2808 sm reindex fails to run 2

### DIFF
--- a/haystack/__init__.py
+++ b/haystack/__init__.py
@@ -15,7 +15,6 @@ __version__ = (2, 5, 0)
 
 default_app_config = 'haystack.apps.HaystackConfig'
 
-
 # Help people clean up from 1.X.
 if hasattr(settings, 'HAYSTACK_SITECONF'):
     raise ImproperlyConfigured('The HAYSTACK_SITECONF setting is no longer used & can be removed.')

--- a/haystack/apps.py
+++ b/haystack/apps.py
@@ -15,12 +15,6 @@ class HaystackConfig(AppConfig):
     stream = None
 
     def ready(self):
-        # Setup default logging.
-        log = logging.getLogger('haystack')
-        self.stream = logging.StreamHandler()
-        self.stream.setLevel(logging.INFO)
-        log.addHandler(self.stream)
-
         # Setup the signal processor.
         if not self.signal_processor:
             signal_processor_path = getattr(settings, 'HAYSTACK_SIGNAL_PROCESSOR', 'haystack.signals.BaseSignalProcessor')

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -190,7 +190,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
         bulk(self.conn, prepped_docs, index=self.index_name, doc_type='modelresult')
 
         # We are explicitly eliminating the call to self.conn.indices.refresh().
-        # ElasticSearch will do an automatic refresh once per minute. Manually invoking refresh
+        # ElasticSearch will do an automatic refresh once per second. Manually invoking refresh
         # on every update triggers 1000's of unnecessary API calls.
         # The underlying issue is that neither SearchIndex.update nor SearchIndex.update_object
         # pass kwargs to this method, so setting commit to False does not solve the problem.
@@ -213,7 +213,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
             self.conn.delete(index=self.index_name, doc_type='modelresult', id=doc_id, ignore=404)
 
             # We are explicitly eliminating the call to self.conn.indices.refresh().
-            # ElasticSearch will do an automatic refresh once per minute. Manually invoking refresh
+            # ElasticSearch will do an automatic refresh once per second. Manually invoking refresh
             # on every remove triggers 1000's of unnecessary API calls.
 
         except elasticsearch.TransportError as e:

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -189,8 +189,11 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
 
         bulk(self.conn, prepped_docs, index=self.index_name, doc_type='modelresult')
 
-        # if commit:
-        #     self.conn.indices.refresh(index=self.index_name)
+        # We are explicitly eliminating the call to self.conn.indices.refresh().
+        # ElasticSearch will do an automatic refresh once per minute. Manually invoking refresh
+        # on every update triggers 1000's of unnecessary API calls.
+        # The underlying issue is that neither SearchIndex.update nor SearchIndex.update_object
+        # pass kwargs to this method, so setting commit to False does not solve the problem.
 
     def remove(self, obj_or_string, commit=True):
         doc_id = get_identifier(obj_or_string)
@@ -209,8 +212,10 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
         try:
             self.conn.delete(index=self.index_name, doc_type='modelresult', id=doc_id, ignore=404)
 
-            # if commit:
-            #     self.conn.indices.refresh(index=self.index_name)
+            # We are explicitly eliminating the call to self.conn.indices.refresh().
+            # ElasticSearch will do an automatic refresh once per minute. Manually invoking refresh
+            # on every remove triggers 1000's of unnecessary API calls.
+
         except elasticsearch.TransportError as e:
             if not self.silently_fail:
                 raise

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -189,8 +189,8 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
 
         bulk(self.conn, prepped_docs, index=self.index_name, doc_type='modelresult')
 
-        if commit:
-            self.conn.indices.refresh(index=self.index_name)
+        # if commit:
+        #     self.conn.indices.refresh(index=self.index_name)
 
     def remove(self, obj_or_string, commit=True):
         doc_id = get_identifier(obj_or_string)
@@ -209,8 +209,8 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
         try:
             self.conn.delete(index=self.index_name, doc_type='modelresult', id=doc_id, ignore=404)
 
-            if commit:
-                self.conn.indices.refresh(index=self.index_name)
+            # if commit:
+            #     self.conn.indices.refresh(index=self.index_name)
         except elasticsearch.TransportError as e:
             if not self.silently_fail:
                 raise

--- a/haystack/indexes.py
+++ b/haystack/indexes.py
@@ -350,6 +350,12 @@ class SearchIndex(with_metaclass(DeclarativeMetaclass, threading.local)):
         """
         return self.get_model()._default_manager.all()
 
+    def pre_process_data(self, queryset):
+        """
+        Will allow an "index" to do some preprocessing of the data in it's slice
+        before the actual data is indexed
+        """
+
 
 class BasicSearchIndex(SearchIndex):
     text = CharField(document=True, use_template=True)

--- a/haystack/indexes.py
+++ b/haystack/indexes.py
@@ -352,7 +352,7 @@ class SearchIndex(with_metaclass(DeclarativeMetaclass, threading.local)):
 
     def pre_process_data(self, queryset):
         """
-        Will allow an "index" to do some preprocessing of the data in it's slice
+        Will allow an "index" to do some preprocessing of the data in its slice
         before the actual data is indexed
         """
 

--- a/haystack/inputs.py
+++ b/haystack/inputs.py
@@ -21,7 +21,7 @@ class BaseInput(object):
         self.kwargs = kwargs
 
     def __repr__(self):
-        return u"<%s '%s'>" % (self.__class__.__name__, self.__unicode__().encode('utf8'))
+        return u"<%s '%s'>" % (self.__class__.__name__, self.__str__())
 
     def __str__(self):
         return force_text(self.query_string)

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -82,9 +82,10 @@ def do_update(backend, index, qs, start, end, total, verbosity=1, commit=True,
 
             if verbosity >= 2:
                 if is_parent_process:
-                    logger.info("  indexed {} - {} of {} in {}.  Took {}".format(
+                    logger.info("  indexed {} - {} of {}.  Took {}".format(
                         start + 1,
-                        end, total,
+                        end,
+                        total,
                         time_delta
                     ))
                 else:

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -80,6 +80,7 @@ def do_update(backend, index, qs, start, end, total, verbosity=1, commit=True,
     retries = 0
     while retries < max_retries:
         try:
+            index.pre_process_data(current_qs)
             # FIXME: Get the right backend.
             backend.update(index, current_qs, commit=commit)
             if verbosity >= 2 and retries:

--- a/haystack/management/commands/update_index.py
+++ b/haystack/management/commands/update_index.py
@@ -21,13 +21,12 @@ DEFAULT_BATCH_SIZE = None
 DEFAULT_AGE = None
 DEFAULT_MAX_RETRIES = 5
 
-LOG = multiprocessing.log_to_stderr(level=logging.WARNING)
 logger = logging.getLogger('haystack')
 
 
 def update_worker(args):
     if len(args) != 10:
-        LOG.error('update_worker received incorrect arguments: %r', args)
+        logger.error('update_worker received incorrect arguments: %r', args)
         raise ValueError('update_worker received incorrect arguments')
 
     model, start, end, total, using, start_date, end_date, verbosity, commit, max_retries = args
@@ -123,10 +122,10 @@ def do_update(backend, index, qs, start, end, total, verbosity=1, commit=True,
                 error_msg += ' (pid %(pid)s): %(exc)s'
 
             if retries >= max_retries:
-                LOG.error(error_msg, error_context, exc_info=True)
+                logger.error(error_msg, error_context, exc_info=True)
                 raise
             elif verbosity >= 2:
-                LOG.warning(error_msg, error_context, exc_info=True)
+                logger.warning(error_msg, error_context, exc_info=True)
 
             # If going to try again, sleep a bit before
             time.sleep(2 ** retries)
@@ -201,9 +200,9 @@ class Command(BaseCommand):
         end_date = options.get('end_date')
 
         if self.verbosity > 2:
-            LOG.setLevel(logging.DEBUG)
+            logger.setLevel(logging.DEBUG)
         elif self.verbosity > 1:
-            LOG.setLevel(logging.INFO)
+            logger.setLevel(logging.INFO)
 
         if age is not None:
             self.start_date = now() - timedelta(hours=int(age))
@@ -230,7 +229,7 @@ class Command(BaseCommand):
                 try:
                     self.update_backend(label, using)
                 except:
-                    LOG.exception("Error updating %s using %s ", label, using)
+                    logger.exception("Error updating %s using %s ", label, using)
                     raise
 
     def update_backend(self, label, using):


### PR DESCRIPTION
We use django-haystack 2.3.0.  This will not work with out current version of django.  This PR adds all the commits we added in the `haystack-2-3-1-20161014` branch, minus merge commits and commits for features we had reverted to our forks master. Master is using version 2.5.1 which should play better with our current version of django.

Here's the diff of what had been added to the `haystack-2-3-1-20161014` branch:

https://github.com/RueLaLaTech/django-haystack/compare/a32c8993ae986fe22d362d477b434b39b13a2cc6..7a194b65f7b1b53f86db01b0987ab483e8b41b84#diff-13afbd7c77d48fd0bfb1ce436259b136

The changes in this PR should be roughly equivalent